### PR TITLE
Rename `as_…` methods to `connect_…`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2021-12-23
+### Changed
+ - Rename `wire` methods `as_…` to `connect_…`
+
+### Added
+ - Extended tests to increase test coverage for `wire`
+
 ## [0.4.2] - 2021-12-23
 ### Added
  - Reimplemented `ToggleableOutputPin` for `wire` with correct locking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal-sync-pins"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "embedded-hal",
  "embedded-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-hal-sync-pins"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Niclas Hoyer <info@niclashoyer.de>"]
 edition = "2018"
 description = "embedded-hal pin implementations that can be shared between threads"


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/niclashoyer/embedded-hal-sync-pins/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/niclashoyer/embedded-hal-sync-pins/blob/master/CHANGELOG.md
-->
